### PR TITLE
Tweak elm-geometry example slightly

### DIFF
--- a/src/KMeans.elm
+++ b/src/KMeans.elm
@@ -76,13 +76,13 @@ This function offers more flexibility in the type of coordinate you have: Just t
 
 Or using `ianmackenzie/elm-geometry` and `ianmackenzie/elm-units`
 
-    point2d : Point2d Pixels Float -> List Float
+    point2d : Point2d Pixels coordinates -> List Float
     point2d point =
         let
-            ( a, b ) =
-                Point2d.toTuple Pixels.inPixels point
+            { x, y } =
+                Point2d.toPixels point
         in
-        [ a, b ]
+        [ x, y ]
 
     myPoint2ds : List (Point2d Pixels Float)
 


### PR DESCRIPTION
- The second `Point2d` type parameter is used to indicate a particular coordinate system like `WorldCoordinates` or `ScreenCoordinates`, not what type of values (`Int`/`Float`) individual coordinates have; in this example you could leave it as a free type parameter or lock it to something arbitrary like `Screen`/`ScreenCoordinates`.
- `toPixels` is slightly more succinct and also more efficient than `toTuple`, since there are no extra function calls or allocations. The internal representation of a `Point2d` is just `{ x : Float, y : Float }` stored in base units (pixels/meters), so in cases like this where you want the base units, `elm-geometry` can simply return that internal record directly.